### PR TITLE
Additional `Activity` aliases and intent filters

### DIFF
--- a/agent/src/main/AndroidManifest.xml
+++ b/agent/src/main/AndroidManifest.xml
@@ -58,27 +58,60 @@
             android:targetActivity="com.WithSecure.dz.activities.StartBroadcastActivity"
             android:exported="true" />
         <activity-alias
-            android:targetActivity=".activities.EndpointActivity"
-            android:name="com.WithSecure.dz.activities.EndpointActivity"
+            android:name=".activities.EndpointActivity"
+            android:targetActivity="com.WithSecure.dz.activities.EndpointActivity"
             android:label="@string/title_activity_endpoint" />
         <activity-alias
-            android:targetActivity=".activities.EndpointSettingsActivity"
-            android:name="com.WithSecure.dz.activities.EndpointSettingsActivity"
+            android:name=".activities.EndpointSettingsActivity"
+            android:targetActivity="com.WithSecure.dz.activities.EndpointSettingsActivity"
             android:label="@string/endpoint_new" />
         <activity-alias
-            android:targetActivity=".activities.ServerActivity"
-            android:name="com.WithSecure.dz.activities.ServerActivity"
+            android:name=".activities.ServerActivity"
+            android:targetActivity="com.WithSecure.dz.activities.ServerActivity"
             android:label="@string/title_activity_server" />
         <activity-alias
-            android:targetActivity=".activities.SettingsActivity"
-            android:name="com.WithSecure.dz.activities.SettingsActivity"
+            android:name=".activities.SettingsActivity"
+            android:targetActivity="com.WithSecure.dz.activities.SettingsActivity"
             android:label="@string/title_activity_settings" />
         <activity-alias
-            android:targetActivity=".helpers.IntentProxyToContentProvider"
-            android:name="com.WithSecure.dz.helpers.IntentProxyToContentProvider"
+            android:name=".helpers.IntentProxyToContentProvider"
+            android:targetActivity="com.WithSecure.dz.helpers.IntentProxyToContentProvider"
             android:exported="true" />
 
-        
+        <activity-alias
+            android:name="com.withsecure.dz.activities.AboutActivity"
+            android:label="@string/title_about"
+            android:targetActivity="com.WithSecure.dz.activities.AboutActivity" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.MainActivity"
+            android:targetActivity="com.WithSecure.dz.activities.MainActivity"
+            android:label="@string/title_activity_main"
+            android:exported="true" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.StartBroadcastActivity"
+            android:targetActivity="com.WithSecure.dz.activities.StartBroadcastActivity"
+            android:exported="true" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.EndpointActivity"
+            android:targetActivity="com.WithSecure.dz.activities.EndpointActivity"
+            android:label="@string/title_activity_endpoint" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.EndpointSettingsActivity"
+            android:targetActivity="com.WithSecure.dz.activities.EndpointSettingsActivity"
+            android:label="@string/endpoint_new" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.ServerActivity"
+            android:targetActivity="com.WithSecure.dz.activities.ServerActivity"
+            android:label="@string/title_activity_server" />
+        <activity-alias
+            android:name="com.withsecure.dz.activities.SettingsActivity"
+            android:targetActivity="com.WithSecure.dz.activities.SettingsActivity"
+            android:label="@string/title_activity_settings" />
+        <activity-alias
+            android:name="com.withsecure.dz.helpers.IntentProxyToContentProvider"
+            android:targetActivity="com.WithSecure.dz.helpers.IntentProxyToContentProvider"
+            android:exported="true" />
+
         <receiver 
             android:name="com.WithSecure.dz.receivers.StartServiceReceiver"
             android:exported="true"

--- a/agent/src/main/AndroidManifest.xml
+++ b/agent/src/main/AndroidManifest.xml
@@ -19,17 +19,10 @@
         <activity
             android:name="com.WithSecure.dz.activities.MainActivity"
             android:label="@string/title_activity_main"
-            android:exported="true"
-            >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:exported="true" />
         <activity
             android:name="com.WithSecure.dz.activities.StartBroadcastActivity"
-            android:exported="true"
-            />
+            android:exported="true" />
         <activity
             android:name="com.WithSecure.dz.activities.EndpointActivity"
             android:label="@string/title_activity_endpoint" />
@@ -44,8 +37,47 @@
             android:label="@string/title_activity_settings" />
         <activity
             android:name="com.WithSecure.dz.helpers.IntentProxyToContentProvider"
-            android:exported="true"
-            />
+            android:exported="true" />
+
+        <activity-alias
+            android:name=".activities.AboutActivity"
+            android:label="@string/title_about"
+            android:targetActivity="com.WithSecure.dz.activities.AboutActivity" />
+        <activity-alias
+            android:name=".activities.MainActivity"
+            android:targetActivity="com.WithSecure.dz.activities.MainActivity"
+            android:label="@string/title_activity_main"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+        <activity-alias
+            android:name=".activities.StartBroadcastActivity"
+            android:targetActivity="com.WithSecure.dz.activities.StartBroadcastActivity"
+            android:exported="true" />
+        <activity-alias
+            android:targetActivity=".activities.EndpointActivity"
+            android:name="com.WithSecure.dz.activities.EndpointActivity"
+            android:label="@string/title_activity_endpoint" />
+        <activity-alias
+            android:targetActivity=".activities.EndpointSettingsActivity"
+            android:name="com.WithSecure.dz.activities.EndpointSettingsActivity"
+            android:label="@string/endpoint_new" />
+        <activity-alias
+            android:targetActivity=".activities.ServerActivity"
+            android:name="com.WithSecure.dz.activities.ServerActivity"
+            android:label="@string/title_activity_server" />
+        <activity-alias
+            android:targetActivity=".activities.SettingsActivity"
+            android:name="com.WithSecure.dz.activities.SettingsActivity"
+            android:label="@string/title_activity_settings" />
+        <activity-alias
+            android:targetActivity=".helpers.IntentProxyToContentProvider"
+            android:name="com.WithSecure.dz.helpers.IntentProxyToContentProvider"
+            android:exported="true" />
+
         
         <receiver 
             android:name="com.WithSecure.dz.receivers.StartServiceReceiver"
@@ -53,6 +85,8 @@
             android:process=":remote">
             <intent-filter>
                 <action android:name="com.mwr.dz.PWN"/>
+                <action android:name="com.WithSecure.dz.PWN"/>
+                <action android:name="com.withsecure.dz.PWN"/>
             </intent-filter>
         </receiver>
 
@@ -62,6 +96,8 @@
             android:process=":remote">
             <intent-filter>
                 <action android:name="com.boops.boops.START"/>
+                <action android:name="com.withsecure.dz.START"/>
+                <action android:name="com.WithSecure.dz.START"/>
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
The bundle identifier of the default drozer agent is `com.withsecure.dz`. Annoyingly, all components and packages follow a different naming convention - starting with `com.WithSecure.dz`. This leads to awkward edge cases in scenarios where a user wants to use drozer to launch its own activities.

This commit introduces a number of additional aliases to hopefully catch most edge cases. This will also be handy in scenarios where a user chooses to create a custom agent with their own bundle identifier and/or namespace.