### PR TITLE
YAY

### DIFF
--- a/agent/src/main/java/com/WithSecure/dz/Agent.java
+++ b/agent/src/main/java/com/WithSecure/dz/Agent.java
@@ -176,7 +176,7 @@ public class Agent {
 		// store whatever UID we have created in the Preferences
 		Editor edit = this.getSettings().edit();
 		edit.putString(Agent.AGENT_ID, this.uid);
-		edit.commit();
+		edit.apply();
 		
 		return this.uid;
 	}

--- a/agent/src/main/java/com/WithSecure/dz/service_connectors/ServerServiceConnection.java
+++ b/agent/src/main/java/com/WithSecure/dz/service_connectors/ServerServiceConnection.java
@@ -83,7 +83,7 @@ public class ServerServiceConnection implements ServiceConnection {
 		
 		Editor edit = Agent.getInstance().getSettings().edit();
 		edit.putBoolean("localServerEnabled", true);
-		edit.commit();
+		edit.apply();
 		
 		server.enabled = true;
 		server.notifyObservers();
@@ -97,7 +97,7 @@ public class ServerServiceConnection implements ServiceConnection {
 		
 		Editor edit = Agent.getInstance().getSettings().edit();
 		edit.putBoolean("localServerEnabled", false);
-		edit.commit();
+		edit.apply();
 		
 		server.enabled = false;
 		server.notifyObservers();


### PR DESCRIPTION
Changed some stuff from `editor.commit()` to `editor.apply()` per Android Studio's recommendation:

```
Consider using apply() instead; commit writes its data to persistent storage immediately, whereas apply will handle it in the background More... (Ctrl+F1) 
Inspection info:Consider using apply() instead of commit on shared preferences. Whereas commit blocks and writes its data to persistent storage immediately, apply will handle it in the background.
```