### PR TITLE
Add TLS support with auto-generated certificates

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -18,6 +18,7 @@ android {
             targetSdkVersion 33
             buildConfigField "boolean", "IS_PENTEST", "false"
             buildConfigField "boolean", "AUTO_PASSWORD", "false"
+            buildConfigField "boolean", "AUTO_SSL", "true"
             resValue "string", "app_name", "drozer Agent"
         }
         pentest {
@@ -26,6 +27,7 @@ android {
             targetSdkVersion 34
             buildConfigField "boolean", "IS_PENTEST", "true"
             buildConfigField "boolean", "AUTO_PASSWORD", "true"
+            buildConfigField "boolean", "AUTO_SSL", "true"
             resValue "string", "app_name", "drozer Agent (Pentest)"
         }
     }

--- a/agent/src/main/java/com/reversec/dz/activities/MainActivity.java
+++ b/agent/src/main/java/com/reversec/dz/activities/MainActivity.java
@@ -52,7 +52,7 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         
         Agent.getInstance().setContext(this.getApplicationContext());
-        PentestPasswordManager.ensurePasswordGenerated(this.getApplicationContext());
+        PentestPasswordManager.ensureSecurityDefaults(this.getApplicationContext());
 
         setContentView(R.layout.activity_main);
         

--- a/agent/src/main/java/com/reversec/dz/services/ServerService.java
+++ b/agent/src/main/java/com/reversec/dz/services/ServerService.java
@@ -34,9 +34,12 @@ import com.reversec.dz.BuildConfig;
 import com.reversec.dz.R;
 import com.reversec.dz.activities.MainActivity;
 import com.reversec.dz.models.ServerSettings;
+import com.reversec.dz.util.CertificateManager;
 import com.reversec.dz.util.PentestPasswordManager;
 import com.reversec.jsolar.api.connectors.Connector;
 import com.reversec.jsolar.api.links.Server;
+
+import javax.net.ssl.KeyManager;
 
 public class ServerService extends ConnectorService {
 
@@ -183,7 +186,7 @@ public class ServerService extends ConnectorService {
 
 		if(intent != null && intent.getCategories() != null && intent.getCategories().contains("com.reversec.dz.START_EMBEDDED")) {
 			Agent.getInstance().setContext(this.getApplicationContext());
-			PentestPasswordManager.ensurePasswordGenerated(this.getApplicationContext());
+			PentestPasswordManager.ensureSecurityDefaults(this.getApplicationContext());
 			this.startServer();
 		}
 
@@ -230,6 +233,12 @@ public class ServerService extends ConnectorService {
 		String text = "Listening on " + getLocalAddressesString(server_parameters.getPort());
 		if (BuildConfig.IS_PENTEST && server_parameters.hasPassword()) {
 			text += "\nPassword: " + server_parameters.getPassword();
+		}
+		if (server_parameters.isSSL()) {
+			String phrase = CertificateManager.getSecurityPhrase(getApplicationContext());
+			if (phrase != null) {
+				text += "\nTLS: " + phrase;
+			}
 		}
 		return text;
 	}
@@ -318,6 +327,14 @@ public class ServerService extends ConnectorService {
 					.edit().putBoolean("localServerEnabled", true).apply();
 
 			(new ServerSettings()).load(getBaseContext(), this.server_parameters);
+
+			if (this.server_parameters.isSSL()) {
+				CertificateManager.ensureCertificateGenerated(getApplicationContext());
+				KeyManager[] kms = CertificateManager.getKeyManagers(getApplicationContext());
+				if (kms != null) {
+					this.server_parameters.setKeyManagers(kms);
+				}
+			}
 
 			this.server_parameters.enabled = true;
 			this.server = new Server(this.server_parameters, Agent.getInstance().getDeviceInfo());

--- a/agent/src/main/java/com/reversec/dz/util/CertificateManager.java
+++ b/agent/src/main/java/com/reversec/dz/util/CertificateManager.java
@@ -1,0 +1,183 @@
+package com.reversec.dz.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import com.reversec.dz.R;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+
+public class CertificateManager {
+
+    private static final String TAG = "CertificateManager";
+    private static final String KS_FILENAME = "drozer-server.p12";
+    // Bump this to force key regeneration when the generation logic changes.
+    private static final int CERT_VERSION = 4;
+    private static final String PREF_CERT_VERSION = "cert:version";
+
+    /**
+     * Ensures a server certificate exists as a PKCS12 file in app-private storage.
+     * Generates a fresh RSA-2048 key + self-signed X.509 v1 cert if missing or outdated.
+     */
+    public static void ensureCertificateGenerated(Context context) {
+        try {
+            SharedPreferences prefs = context.getSharedPreferences(
+                    context.getPackageName() + "_preferences", Context.MODE_MULTI_PROCESS);
+            int storedVersion = prefs.getInt(PREF_CERT_VERSION, 0);
+            File ksFile = new File(context.getFilesDir(), KS_FILENAME);
+
+            if (ksFile.exists() && storedVersion >= CERT_VERSION) {
+                Log.i(TAG, "Certificate already exists (v" + storedVersion + ")");
+                return;
+            }
+
+            if (ksFile.exists()) {
+                Log.i(TAG, "Deleting outdated certificate (v" + storedVersion + " < v" + CERT_VERSION + ")");
+                ksFile.delete();
+            }
+
+            KeyStore ks = SelfSignedCertGenerator.generate();
+            try (FileOutputStream fos = new FileOutputStream(ksFile)) {
+                ks.store(fos, SelfSignedCertGenerator.STORE_PASS);
+            }
+
+            prefs.edit().putInt(PREF_CERT_VERSION, CERT_VERSION).apply();
+            Log.i(TAG, "Generated new server certificate (v" + CERT_VERSION + ")");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to generate certificate", e);
+        }
+    }
+
+    /**
+     * Returns KeyManagers backed by the generated PKCS12 keystore, or by the
+     * legacy static BKS file as a last-resort fallback.
+     */
+    public static KeyManager[] getKeyManagers(Context context) {
+        try {
+            File ksFile = new File(context.getFilesDir(), KS_FILENAME);
+            if (ksFile.exists()) {
+                KeyStore ks = KeyStore.getInstance("PKCS12");
+                try (FileInputStream fis = new FileInputStream(ksFile)) {
+                    ks.load(fis, SelfSignedCertGenerator.STORE_PASS);
+                }
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+                        KeyManagerFactory.getDefaultAlgorithm());
+                kmf.init(ks, SelfSignedCertGenerator.STORE_PASS);
+                return kmf.getKeyManagers();
+            }
+
+            // Legacy fallback: static BKS shipped with the app
+            return getKeyManagersFromBks(context);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get KeyManagers", e);
+            return null;
+        }
+    }
+
+    private static KeyManager[] getKeyManagersFromBks(Context context) throws Exception {
+        File bksFile = new File(context.getFilesDir(), "drozer.bks");
+        if (!bksFile.exists()) return null;
+
+        KeyStore ks = KeyStore.getInstance("BKS");
+        ks.load(new FileInputStream(bksFile), "drozer".toCharArray());
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "drozer".toCharArray());
+        return kmf.getKeyManagers();
+    }
+
+    /**
+     * Returns the SHA-256 fingerprint of the server certificate as a colon-separated
+     * hex string, e.g. "AB:CD:12:34:...".
+     */
+    public static String getCertificateFingerprint(Context context) {
+        try {
+            byte[] fingerprintBytes = getFingerprintBytes(context);
+            if (fingerprintBytes == null) return null;
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < fingerprintBytes.length; i++) {
+                if (i > 0) sb.append(':');
+                sb.append(String.format("%02X", fingerprintBytes[i]));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get certificate fingerprint", e);
+            return null;
+        }
+    }
+
+    /**
+     * Returns a human-readable security phrase derived from the certificate fingerprint.
+     */
+    public static String getSecurityPhrase(Context context) {
+        try {
+            byte[] fingerprintBytes = getFingerprintBytes(context);
+            if (fingerprintBytes == null || fingerprintBytes.length < 6) return null;
+
+            String[] words = loadWordlist(context);
+            if (words == null || words.length == 0) return null;
+
+            StringBuilder phrase = new StringBuilder();
+            for (int i = 0; i < 3; i++) {
+                int hi = fingerprintBytes[i * 2] & 0xFF;
+                int lo = fingerprintBytes[i * 2 + 1] & 0xFF;
+                int index = ((hi << 8) | lo) % words.length;
+                if (i > 0) phrase.append('-');
+                phrase.append(words[index]);
+            }
+            return phrase.toString();
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get security phrase", e);
+            return null;
+        }
+    }
+
+    private static byte[] getFingerprintBytes(Context context) throws Exception {
+        File ksFile = new File(context.getFilesDir(), KS_FILENAME);
+        if (!ksFile.exists()) return null;
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream fis = new FileInputStream(ksFile)) {
+            ks.load(fis, SelfSignedCertGenerator.STORE_PASS);
+        }
+
+        Certificate cert = ks.getCertificate(SelfSignedCertGenerator.ALIAS);
+        if (cert == null) return null;
+
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        return md.digest(cert.getEncoded());
+    }
+
+    private static String[] loadWordlist(Context context) {
+        List<String> words = new ArrayList<>();
+        try (InputStream is = context.getResources().openRawResource(R.raw.wordlist);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    words.add(line);
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to load wordlist", e);
+            return null;
+        }
+        return words.toArray(new String[0]);
+    }
+}

--- a/agent/src/main/java/com/reversec/dz/util/CertificateManager.java
+++ b/agent/src/main/java/com/reversec/dz/util/CertificateManager.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import com.reversec.dz.Agent;
 import com.reversec.dz.R;
 
 import java.io.BufferedReader;
@@ -90,11 +91,14 @@ public class CertificateManager {
     }
 
     private static KeyManager[] getKeyManagersFromBks(Context context) throws Exception {
-        File bksFile = new File(context.getFilesDir(), "drozer.bks");
+        // The app ships agent.bks (see Agent.DEFAULT_KEYSTORE), copied to filesDir on startup.
+        File bksFile = new File(context.getFilesDir(), Agent.DEFAULT_KEYSTORE);
         if (!bksFile.exists()) return null;
 
         KeyStore ks = KeyStore.getInstance("BKS");
-        ks.load(new FileInputStream(bksFile), "drozer".toCharArray());
+        try (FileInputStream fis = new FileInputStream(bksFile)) {
+            ks.load(fis, "drozer".toCharArray());
+        }
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(ks, "drozer".toCharArray());
         return kmf.getKeyManagers();

--- a/agent/src/main/java/com/reversec/dz/util/PentestPasswordManager.java
+++ b/agent/src/main/java/com/reversec/dz/util/PentestPasswordManager.java
@@ -46,7 +46,7 @@ public class PentestPasswordManager {
                     .putBoolean(Server.SERVER_SSL, true)
                     .putBoolean("server:ssl:auto_configured", true)
                     .apply();
-            Log.i(TAG, "Auto-enabled SSL for pentest mode");
+            Log.i(TAG, "Auto-enabled SSL based on configuration");
         }
     }
 

--- a/agent/src/main/java/com/reversec/dz/util/PentestPasswordManager.java
+++ b/agent/src/main/java/com/reversec/dz/util/PentestPasswordManager.java
@@ -20,6 +20,36 @@ public class PentestPasswordManager {
 
     private static final String TAG = "PentestPasswordManager";
 
+    /**
+     * Ensures pentest security defaults are applied: auto-generates a password and
+     * enables SSL if the corresponding BuildConfig flags are set.
+     */
+    public static void ensureSecurityDefaults(Context context) {
+        ensurePasswordGenerated(context);
+        ensureSslEnabled(context);
+    }
+
+    private static void ensureSslEnabled(Context context) {
+        if (!BuildConfig.AUTO_SSL) return;
+
+        SharedPreferences prefs = context.getSharedPreferences(
+                context.getPackageName() + "_preferences", Context.MODE_MULTI_PROCESS);
+
+        // Don't re-enable if user explicitly disabled after auto-config
+        if (prefs.getBoolean("server:ssl:auto_configured", false)
+                && !prefs.getBoolean(Server.SERVER_SSL, false)) {
+            return;
+        }
+
+        if (!prefs.getBoolean(Server.SERVER_SSL, false)) {
+            prefs.edit()
+                    .putBoolean(Server.SERVER_SSL, true)
+                    .putBoolean("server:ssl:auto_configured", true)
+                    .apply();
+            Log.i(TAG, "Auto-enabled SSL for pentest mode");
+        }
+    }
+
     public static void ensurePasswordGenerated(Context context) {
         if (!BuildConfig.AUTO_PASSWORD) return;
 

--- a/agent/src/main/java/com/reversec/dz/util/SelfSignedCertGenerator.java
+++ b/agent/src/main/java/com/reversec/dz/util/SelfSignedCertGenerator.java
@@ -1,0 +1,136 @@
+package com.reversec.dz.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.Signature;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Generates a self-signed RSA-2048 / SHA256withRSA X.509 v1 certificate
+ * using only standard Java crypto APIs. No BouncyCastle, no Android Keystore.
+ */
+class SelfSignedCertGenerator {
+
+    static final String ALIAS = "drozer-server";
+    static final char[] STORE_PASS = "drozer".toCharArray();
+
+    // sha256WithRSAEncryption = 1.2.840.113549.1.1.11
+    private static final byte[] OID_SHA256_WITH_RSA = {
+            0x06, 0x09,
+            0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x0b
+    };
+    // commonName = 2.5.4.3
+    private static final byte[] OID_COMMON_NAME = {
+            0x06, 0x03, 0x55, 0x04, 0x03
+    };
+
+    static KeyStore generate() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        Calendar cal = Calendar.getInstance();
+        Date notBefore = cal.getTime();
+        cal.add(Calendar.YEAR, 10);
+        Date notAfter = cal.getTime();
+
+        byte[] tbs = buildTbsCertificate(keyPair, BigInteger.ONE, notBefore, notAfter);
+
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initSign(keyPair.getPrivate());
+        sig.update(tbs);
+        byte[] signature = sig.sign();
+
+        byte[] certDer = derSequence(concat(
+                tbs,
+                derSequence(concat(OID_SHA256_WITH_RSA, derNull())),
+                derBitString(signature)));
+
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        X509Certificate cert = (X509Certificate) cf.generateCertificate(
+                new ByteArrayInputStream(certDer));
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+        ks.setKeyEntry(ALIAS, keyPair.getPrivate(), STORE_PASS,
+                new java.security.cert.Certificate[]{cert});
+        return ks;
+    }
+
+    private static byte[] buildTbsCertificate(KeyPair keyPair, BigInteger serial,
+                                               Date notBefore, Date notAfter) throws Exception {
+        byte[] nameDer = buildName("drozer-agent");
+        return derSequence(concat(
+                derInteger(serial.toByteArray()),
+                derSequence(concat(OID_SHA256_WITH_RSA, derNull())),
+                nameDer,
+                derSequence(concat(derUtcTime(notBefore), derUtcTime(notAfter))),
+                nameDer,
+                keyPair.getPublic().getEncoded()));
+    }
+
+    private static byte[] buildName(String cn) throws Exception {
+        byte[] cnValue = derTagged(0x0C, cn.getBytes("UTF-8"));
+        byte[] atv = derSequence(concat(OID_COMMON_NAME, cnValue));
+        byte[] rdn = derTagged(0x31, atv);
+        return derSequence(rdn);
+    }
+
+    // -- DER primitives --
+
+    private static byte[] derTagged(int tag, byte[] content) {
+        byte[] len = derLength(content.length);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(tag);
+        out.write(len, 0, len.length);
+        out.write(content, 0, content.length);
+        return out.toByteArray();
+    }
+
+    private static byte[] derSequence(byte[] content) { return derTagged(0x30, content); }
+
+    private static byte[] derInteger(byte[] value) { return derTagged(0x02, value); }
+
+    private static byte[] derNull() { return new byte[]{0x05, 0x00}; }
+
+    private static byte[] derBitString(byte[] value) {
+        byte[] content = new byte[value.length + 1];
+        content[0] = 0x00;
+        System.arraycopy(value, 0, content, 1, value.length);
+        return derTagged(0x03, content);
+    }
+
+    private static byte[] derUtcTime(Date date) throws Exception {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyMMddHHmmss");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return derTagged(0x17, (sdf.format(date) + "Z").getBytes("ASCII"));
+    }
+
+    private static byte[] derLength(int len) {
+        if (len < 0x80) return new byte[]{(byte) len};
+        if (len < 0x100) return new byte[]{(byte) 0x81, (byte) len};
+        if (len < 0x10000) return new byte[]{(byte) 0x82, (byte) (len >> 8), (byte) len};
+        return new byte[]{(byte) 0x83, (byte) (len >> 16), (byte) (len >> 8), (byte) len};
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int total = 0;
+        for (byte[] p : parts) total += p.length;
+        byte[] out = new byte[total];
+        int pos = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, pos, p.length);
+            pos += p.length;
+        }
+        return out;
+    }
+}

--- a/agent/src/main/java/com/reversec/dz/views/ServerListRowView.java
+++ b/agent/src/main/java/com/reversec/dz/views/ServerListRowView.java
@@ -22,6 +22,7 @@ import android.widget.ToggleButton;
 
 import com.reversec.dz.BuildConfig;
 import com.reversec.dz.R;
+import com.reversec.dz.util.CertificateManager;
 import com.reversec.jsolar.api.connectors.Server;
 import com.reversec.jsolar.api.connectors.Server.OnChangeListener;
 
@@ -79,6 +80,12 @@ public class ServerListRowView extends LinearLayout implements Observer, OnCheck
 		String displayText = getLocalAddressesString(this.server_parameters.getPort());
 		if (BuildConfig.IS_PENTEST && this.server_parameters.hasPassword()) {
 			displayText += "\nPassword: " + this.server_parameters.getPassword();
+		}
+		if (this.server_parameters.isSSL()) {
+			String phrase = CertificateManager.getSecurityPhrase(getContext());
+			if (phrase != null) {
+				displayText += "\nTLS: " + phrase;
+			}
 		}
 		this.adb_server_port_field.setText(displayText);
 		this.adb_server_status_indicator.setConnector(this.server_parameters);

--- a/agent/src/main/res/raw/wordlist.txt
+++ b/agent/src/main/res/raw/wordlist.txt
@@ -2358,6 +2358,7 @@ dropping
 drops
 drought
 drove
+drozer
 drug
 drugs
 drum
@@ -8168,6 +8169,7 @@ wrong
 wrote
 yacht
 yards
+yay
 year
 yearly
 years

--- a/jsolar/src/main/java/com/reversec/jsolar/api/connectors/Server.java
+++ b/jsolar/src/main/java/com/reversec/jsolar/api/connectors/Server.java
@@ -57,9 +57,14 @@ public class Server extends Connector{
 
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keyStore, this.keyPassword);
+            this.keyManagers = keyManagerFactory.getKeyManagers();
         }
 
         return this.keyManagers;
+    }
+
+    public void setKeyManagers(KeyManager[] keyManagers) {
+        this.keyManagers = keyManagers;
     }
 
     public String getPassword() {

--- a/jsolar/src/main/java/com/reversec/jsolar/api/connectors/ServerSocketFactory.java
+++ b/jsolar/src/main/java/com/reversec/jsolar/api/connectors/ServerSocketFactory.java
@@ -1,5 +1,7 @@
 package com.reversec.jsolar.api.connectors;
 
+import android.util.Log;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.security.KeyManagementException;
@@ -7,11 +9,16 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.Arrays;
 
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 
 public class ServerSocketFactory {
+
+    private static final String TAG = "ServerSocketFactory";
+
     public ServerSocket createSocket(Server server) throws CertificateException, IOException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
         if (server.isSSL())
             return this.createSSLSocket(server);
@@ -21,10 +28,21 @@ public class ServerSocketFactory {
 
     public SSLServerSocket createSSLSocket(Server server) throws CertificateException, IOException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
         try {
-            SSLContext context = SSLContext.getInstance("TLS");
-            context.init(server.getKeyManagers(), null, null);
+            KeyManager[] keyManagers = server.getKeyManagers();
+            Log.i(TAG, "KeyManagers: " + (keyManagers != null ? keyManagers.length + " entries" : "null"));
+            if (keyManagers != null) {
+                for (int i = 0; i < keyManagers.length; i++) {
+                    Log.i(TAG, "  KeyManager[" + i + "]: " + keyManagers[i].getClass().getName());
+                }
+            }
 
-            return (SSLServerSocket) context.getServerSocketFactory().createServerSocket(server.getPort());
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(keyManagers, null, null);
+
+            SSLServerSocket ss = (SSLServerSocket) context.getServerSocketFactory().createServerSocket(server.getPort());
+            Log.i(TAG, "Enabled protocols: " + Arrays.toString(ss.getEnabledProtocols()));
+            Log.i(TAG, "Enabled cipher suites: " + Arrays.toString(ss.getEnabledCipherSuites()));
+            return ss;
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("no such algorithm TLS");
         }

--- a/jsolar/src/main/java/com/reversec/jsolar/api/links/Server.java
+++ b/jsolar/src/main/java/com/reversec/jsolar/api/links/Server.java
@@ -18,7 +18,6 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
 import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLServerSocket;
 
 public class Server extends Link{
 

--- a/jsolar/src/main/java/com/reversec/jsolar/api/links/Server.java
+++ b/jsolar/src/main/java/com/reversec/jsolar/api/links/Server.java
@@ -7,6 +7,8 @@ import com.reversec.jsolar.api.transport.SocketTransport;
 import com.reversec.jsolar.connection.SecureConnection;
 import com.reversec.jsolar.logger.LogMessage;
 
+import android.util.Log;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -14,6 +16,9 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLServerSocket;
 
 public class Server extends Link{
 
@@ -81,7 +86,14 @@ public class Server extends Link{
                     this.serverSocket = new ServerSocketFactory().createSocket((com.reversec.jsolar.api.connectors.Server) this.parameters);
 
                     this.log(LogMessage.INFO, "Waiting for connections...");
-                    Socket socket = this.serverSocket.accept();
+                    Socket socket;
+                    try {
+                        socket = this.serverSocket.accept();
+                    } catch (SSLHandshakeException e) {
+                        Log.e("Server", "TLS handshake failed with client", e);
+                        this.log(LogMessage.ERROR, "TLS handshake failed: " + e.getMessage());
+                        continue;
+                    }
 
                     if (socket != null) {
                         this.parameters.setStatus(com.reversec.jsolar.api.connectors.Server.Status.ONLINE);

--- a/jsolar/src/main/java/com/reversec/jsolar/api/transport/SocketTransport.java
+++ b/jsolar/src/main/java/com/reversec/jsolar/api/transport/SocketTransport.java
@@ -28,10 +28,24 @@ public class SocketTransport extends Transport implements SecureTransport {
             this.socket = socket;
             this.socket.setSoTimeout(SO_TIMEOUT);
 
+            if (socket instanceof SSLSocket) {
+                SSLSocket sslSocket = (SSLSocket) socket;
+                Log.i("SocketTransport", "SSLSocket detected, starting explicit handshake...");
+                Log.i("SocketTransport", "Enabled protocols: " + java.util.Arrays.toString(sslSocket.getEnabledProtocols()));
+                try {
+                    sslSocket.startHandshake();
+                    Log.i("SocketTransport", "TLS handshake completed: " + sslSocket.getSession().getProtocol()
+                            + " / " + sslSocket.getSession().getCipherSuite());
+                } catch (IOException e) {
+                    Log.e("SocketTransport", "TLS handshake FAILED", e);
+                    throw e;
+                }
+            }
+
             this.in = socket.getInputStream();
             this.out = socket.getOutputStream();
         } catch (IOException e) {
-            Log.e("SocketConnection", "IOException when grabbing streams: " + e.getMessage());
+            Log.e("SocketTransport", "IOException when grabbing streams: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Generate a self-signed RSA-2048 certificate on first launch using Java DER construction. The cert is stored as PKCS12 in app-private storage with a version mechanism for seamless re-generation if the key spec changes.

A human-readable security phrase (3 words derived from the first 6 bytes of the cert's SHA-256 fingerprint via a wordlist mapping) is displayed in both the UI and notification for both build variants.